### PR TITLE
[kameleon] use release name instead of 'stable' in sources.list

### DIFF
--- a/kameleon/Makefile
+++ b/kameleon/Makefile
@@ -3,7 +3,7 @@
 DEBIAN_VERSION=debian10
 DEBIAN_SUITE=buster
 DOCKER_TAG=oardocker/${DEBIAN_VERSION}
-VERSION:=2019.10.10
+VERSION:=2021.08.20
 
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 #BASE_DOCKERFILES=$(shell find $(ROOT_DIR)/../oardocker/templates -path "*/base/Dockerfile" | grep ${DEBIAN_SUITE})

--- a/kameleon/steps/setup/oardocker_custom_image.yaml
+++ b/kameleon/steps/setup/oardocker_custom_image.yaml
@@ -9,6 +9,8 @@
   - local2in:
     - $${kameleon_data_dir}/apt-preferences
     - /etc/apt/preferences
+  - exec_in: sed -ri 's/ stable/ $${release}/g' /etc/apt/sources.list
+  - exec_in: sed -ri 's/stable/$${release}/g' /etc/apt/preferences
   - exec_in: apt-get update
 
 - get_debian_version:


### PR DESCRIPTION
It is better to use release name, indeed, when a new version of Debian
is release 'stable' will point to it.