### PR TITLE
Importing from collections is deprecated since Python 3.3

### DIFF
--- a/oardocker/compat.py
+++ b/oardocker/compat.py
@@ -33,7 +33,7 @@ if PY3:
     def is_bytes(x):
         return isinstance(x, (bytes, memoryview, bytearray))
 
-    from collections import Callable
+    from collections.abc import Callable
     callable = lambda obj: isinstance(obj, Callable)
 
     def _out(x):

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     author_email='salem@harrache.info',
     version=VERSION,
     url='https://oar.imag.fr/wiki:oar-docker',
+    setup_requires=['wheel'],
     install_requires=[
         'Click',
         'docker',


### PR DESCRIPTION
It stopped working with Python 3.10, now import should be done from
collections.abc
'wheel' is also added as a setup requirement since it's needed to build
the wheel with pip.