### PR TITLE
Fix OAR's API usage when using Debian >= 10

### DIFF
--- a/oardocker/templates/common/images/frontend/systemd/apache2.service.d/override.conf
+++ b/oardocker/templates/common/images/frontend/systemd/apache2.service.d/override.conf
@@ -1,0 +1,2 @@
+[Service]
+NoNewPrivileges=no


### PR DESCRIPTION
API was broken on the frontend when using Debian from buster version, a
500 error was returned by Apache.
This was due to systemd apache2.service unit, NoNewPrivileges=yes breaks
the usage of SUexec.